### PR TITLE
fix/liveseo-menu-rendering-without-user-interaction

### DIFF
--- a/components/header/Drawers.tsx
+++ b/components/header/Drawers.tsx
@@ -71,7 +71,7 @@ function Drawers({ menu, searchbar, children, platform }: Props) {
             }}
             title={displayMenu.value ? "Menu" : "Buscar"}
           >
-            {displayMenu.value && <Menu {...menu} />}
+            {<Menu {...menu} />}
             {searchbar && displaySearchDrawer.value && (
               <div class="w-screen">
                 <Searchbar {...searchbar} />


### PR DESCRIPTION
Removed menuOpen validation to ensure it's always rendered in the DOM.