### PR TITLE
fix/liveseo-remove-params-skuid-href

### DIFF
--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -89,7 +89,7 @@ function ProductCard({
     const relativeLink = relative(link);
     return (
       <li>
-        <a href={relativeLink}>
+        <strong>
           <Avatar
             variant={relativeLink === relativeUrl
               ? "active"
@@ -98,13 +98,13 @@ function ProductCard({
               : "disabled"}
             content={value}
           />
-        </a>
+        </strong>
       </li>
     );
   });
   const cta = (
     <a
-      href={url && relative(url)}
+      href={url?.replace(/\?.*$/, "")}
       aria-label="view product"
       class="btn btn-block"
     >
@@ -191,7 +191,7 @@ function ProductCard({
 
         {/* Product Images */}
         <a
-          href={url && relative(url)}
+          href={url?.replace(/\?.*$/, "")}
           aria-label="view product"
           class="grid grid-cols-1 grid-rows-1 w-full"
         >


### PR DESCRIPTION
Removed skuId parameters from HREFs in the ProductCard (used in product listings on PLPs and similar products on PDPs).

For the main product on the PDP, it is already developed with a button to switch the product displayed on the screen and forwarded to the shopping cart. Thus, the functionality of this has not been affected by the change. It continues to work correctly.